### PR TITLE
Fix upsidedown video record

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -733,7 +733,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             setCamcorderProfile(CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_HIGH), recordAudio);
         }
 
-        mMediaRecorder.setOrientationHint(calcDisplayOrientation(mDisplayOrientation));
+        mMediaRecorder.setOrientationHint(calcCameraRotation(mDisplayOrientation));
 
         if (maxDuration != -1) {
             mMediaRecorder.setMaxDuration(maxDuration);


### PR DESCRIPTION
On Android 7 (Test device: Samsung s7+, Samsung A3, Xperia XA2) the video recorded with FRONT camera in PORTRAIT mode is upsidedown. With this change the video is correctly oriented. thank you!