### PR TITLE
Gravity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -25,9 +25,8 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = '26.0.2'
-    compileSdkVersion = 26
+    compileSdkVersion = 27
     minSdkVersion = 14
-    targetSdkVersion = 26
-    supportLibraryVersion = '26.0.1'
+    targetSdkVersion = 27
+    supportLibraryVersion = '27.1.1'
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -17,8 +17,6 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
-    buildToolsVersion rootProject.ext.buildToolsVersion
-
     defaultConfig {
         applicationId 'com.google.android.cameraview.demo'
         minSdkVersion rootProject.ext.minSdkVersion
@@ -37,16 +35,16 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:design:$supportLibraryVersion"
-    compile project(':library')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:design:$supportLibraryVersion"
+    implementation project(':library')
 
     // Tests
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test:runner:0.5') {
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation('com.android.support.test:runner:0.5') {
         exclude module: 'support-annotations'
     }
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2') {
         exclude module: 'support-annotations'
     }
 }

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -21,15 +21,25 @@
     android:background="@color/primary"
     tools:context=".MainActivity">
 
+    <!-- Margins added to ensure camera preview is actually cropped -->
     <com.google.android.cameraview.CameraView
         android:id="@+id/camera"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:adjustViewBounds="true"
-        android:background="@android:color/black"/>
+        android:layout_height="match_parent"
+        android:layout_margin="16dp"
+        android:scaleType="centerCrop"
+        android:background="@android:color/black"
+        app:gravity="centerFill"/>
+
+    <!--<com.google.android.cameraview.CameraView-->
+        <!--android:id="@+id/camera"-->
+        <!--android:layout_width="match_parent"-->
+        <!--android:layout_height="wrap_content"-->
+        <!--android:layout_alignParentLeft="true"-->
+        <!--android:layout_alignParentStart="true"-->
+        <!--android:layout_alignParentTop="true"-->
+        <!--android:adjustViewBounds="true"-->
+        <!--android:background="@android:color/black"/>-->
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 06 09:02:59 JST 2016
+#Tue Jun 26 17:51:35 EEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -39,15 +38,15 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-annotations:$supportLibraryVersion"
-    compile "com.android.support:support-v4:$supportLibraryVersion"
+    api "com.android.support:support-annotations:$supportLibraryVersion"
+    api "com.android.support:support-v4:$supportLibraryVersion"
 
     // Tests
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test:runner:0.5') {
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation('com.android.support.test:runner:0.5') {
         exclude module: 'support-annotations'
     }
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2') {
         exclude module: 'support-annotations'
     }
 }

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -240,6 +240,16 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     private Rect mInitialCropRegion;
 
+    /**
+     * AllowLegacy used for testing to let chooseCameraIdByFacing() pass through
+     * INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY check.
+     * This is useful when we want to enable Camera2 usage on emulators, that always return
+     * level=LEGACY
+     *
+     * Set <b>true</b> to allow hardware legacy level
+     */
+    private boolean mAllowLegacy = false;
+
     Camera2(Callback callback, PreviewImpl preview, Context context) {
         super(callback, preview);
         mCameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
@@ -591,7 +601,8 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
                 Integer level = characteristics.get(
                         CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
                 if (level == null ||
-                        level == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+                        (level == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY &&
+                            !mAllowLegacy)) {
                     continue;
                 }
                 Integer internal = characteristics.get(CameraCharacteristics.LENS_FACING);
@@ -610,7 +621,8 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
             Integer level = mCameraCharacteristics.get(
                     CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
             if (level == null ||
-                    level == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+                    (level == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY &&
+                        !mAllowLegacy)) {
                 return false;
             }
             Integer internal = mCameraCharacteristics.get(CameraCharacteristics.LENS_FACING);

--- a/library/src/main/base/com/google/android/cameraview/Constants.java
+++ b/library/src/main/base/com/google/android/cameraview/Constants.java
@@ -39,4 +39,7 @@ public interface Constants {
     int WB_FLUORESCENT = 4;
     int WB_INCANDESCENT = 5;
 
+    int GRAVITY_NONE = 0;
+    int GRAVITY_CENTER_FILL = 1;
+    int GRAVITY_CENTER_FIT = 2;
 }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -82,12 +82,24 @@ public class CameraView extends FrameLayout {
 
     private final DisplayOrientationDetector mDisplayOrientationDetector;
 
+    public CameraView(Context context) {
+        this(context, null, false);
+    }
+
     public CameraView(Context context, boolean fallbackToOldApi) {
         this(context, null, fallbackToOldApi);
     }
 
+    public CameraView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0, false);
+    }
+
     public CameraView(Context context, AttributeSet attrs, boolean fallbackToOldApi) {
         this(context, attrs, 0, fallbackToOldApi);
+    }
+
+    public CameraView(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, false);
     }
 
     @SuppressWarnings("WrongConstant")

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -18,6 +18,7 @@ package com.google.android.cameraview;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.media.CamcorderProfile;
 import android.os.Build;
 import android.os.Parcel;
@@ -122,7 +123,6 @@ public class CameraView extends FrameLayout {
             mDisplayOrientationDetector = null;
             return;
         }
-        mAdjustViewBounds = true;
         mContext = context;
 
         // Internal setup
@@ -135,6 +135,22 @@ public class CameraView extends FrameLayout {
         } else {
             mImpl = new Camera2Api23(mCallbacks, preview, context);
         }
+
+        // Attributes
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CameraView, defStyleAttr,
+                R.style.Widget_CameraView);
+        mAdjustViewBounds = a.getBoolean(R.styleable.CameraView_android_adjustViewBounds, false);
+        setFacing(a.getInt(R.styleable.CameraView_facing, FACING_BACK));
+        String aspectRatio = a.getString(R.styleable.CameraView_aspectRatio);
+        if (aspectRatio != null) {
+            setAspectRatio(AspectRatio.parse(aspectRatio));
+        } else {
+            setAspectRatio(Constants.DEFAULT_ASPECT_RATIO);
+        }
+        setAutoFocus(a.getBoolean(R.styleable.CameraView_autoFocus, true));
+        setFlash(a.getInt(R.styleable.CameraView_flash, FLASH_AUTO));
+        setGravity(a.getInt(R.styleable.CameraView_gravity, GRAVITY_NONE));
+        a.recycle();
 
         // Display orientation detector
         mDisplayOrientationDetector = new DisplayOrientationDetector(context) {

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -72,11 +72,23 @@ public class CameraView extends FrameLayout {
     public @interface Flash {
     }
 
+    public static final int GRAVITY_NONE = Constants.GRAVITY_NONE;
+
+    public static final int GRAVITY_CENTER_FILL = Constants.GRAVITY_CENTER_FILL;
+
+    public static final int GRAVITY_CENTER_FIT = Constants.GRAVITY_CENTER_FIT;
+
+    @IntDef({GRAVITY_NONE, GRAVITY_CENTER_FILL, GRAVITY_CENTER_FIT})
+    public @interface Gravity {
+    }
+
     CameraViewImpl mImpl;
 
     private final CallbackBridge mCallbacks;
 
     private boolean mAdjustViewBounds;
+
+    private int mGravity = GRAVITY_NONE;
 
     private Context mContext;
 
@@ -231,6 +243,7 @@ public class CameraView extends FrameLayout {
         state.zoom = getZoom();
         state.whiteBalance = getWhiteBalance();
         state.scanning = getScanning();
+        state.gravity = getGravity();
         return state;
     }
 
@@ -250,6 +263,7 @@ public class CameraView extends FrameLayout {
         setZoom(ss.zoom);
         setWhiteBalance(ss.whiteBalance);
         setScanning(ss.scanning);
+        setGravity(ss.gravity);
     }
 
     public void setUsingCamera2Api(boolean useCamera2) {
@@ -456,6 +470,15 @@ public class CameraView extends FrameLayout {
         return mImpl.getFlash();
     }
 
+    public void setGravity(@Gravity int gravity) {
+        mGravity = gravity;
+    }
+
+    @Gravity
+    public int getGravity() {
+        return mGravity;
+    }
+
     public void setFocusDepth(float value) {
         mImpl.setFocusDepth(value);
     }
@@ -603,6 +626,9 @@ public class CameraView extends FrameLayout {
 
         boolean scanning;
 
+        @Gravity
+        int gravity;
+
         @SuppressWarnings("WrongConstant")
         public SavedState(Parcel source, ClassLoader loader) {
             super(source);
@@ -614,6 +640,7 @@ public class CameraView extends FrameLayout {
             zoom = source.readFloat();
             whiteBalance = source.readInt();
             scanning = source.readByte() != 0;
+            gravity = source.readInt();
         }
 
         public SavedState(Parcelable superState) {
@@ -631,6 +658,7 @@ public class CameraView extends FrameLayout {
             out.writeFloat(zoom);
             out.writeInt(whiteBalance);
             out.writeByte((byte) (scanning ? 1 : 0));
+            out.writeInt(gravity);
         }
 
         public static final Creator<SavedState> CREATOR

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -54,5 +54,21 @@
             -->
             <enum name="redEye" value="4"/>
         </attr>
+        <!-- Camera preview gravity. -->
+        <attr name="gravity" format="enum">
+            <!-- No additional adjustment to the camera preview applied. -->
+            <enum name="none" value="0"/>
+            <!--
+                Camera preview fills available area keeping it's ratio.
+                Preview cropped horizontally or vertically.
+             -->
+            <enum name="centerFill" value="1"/>
+            <!--
+                Camera preview fits available area keeping it's ratio.
+                Preview scaled down a bit with added horizontal or vertical spaces around.
+             -->
+            <enum name="centerFit" value="2"/>
+        </attr>
+
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/public.xml
+++ b/library/src/main/res/values/public.xml
@@ -16,6 +16,7 @@
     <public name="aspectRatio" type="attr"/>
     <public name="autoFocus" type="attr"/>
     <public name="flash" type="attr"/>
+    <public name="gravity" type="attr"/>
 
     <public name="Widget.CameraView" type="style"/>
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -19,6 +19,7 @@
         <item name="aspectRatio">4:3</item>
         <item name="autoFocus">true</item>
         <item name="flash">auto</item>
+        <item name="gravity">none</item>
     </style>
 
 </resources>


### PR DESCRIPTION
- updated toolset (gradle version and SDK)
- returned default Android constructors
- introduced `gravity` attribute for CameraView
- returned attributes loading from the xml

**Details**

My main goal to have an ability to center preview with `fill` or `fit` options.
`gravity` option doesn't depend on `adjustViewBounds` and seems they kind of used for different results. Ensure to set `match_parent` for CameraView for both width and height.

Centration code copied and adjusted from the [RNCameraView.java](https://github.com/react-native-community/react-native-camera/blob/master/android/src/main/java/org/reactnative/camera/RNCameraView.java) so this might be a good reason to refactor `RNCameraView` and just use `centerFit` or `centerFill` option from the base class.

I had to revert attributes loading from the xml, that have been deleted and hardcoded `mAdjustViewBounds = true`. This might break the react-native component. If that's the case, we probably should just set default style to `true` rather then hardcode it in the code.

**Further plans**

I have more plans to improve the library, so it's just a first step to start a discussion on what I should be aware of to not break react-native component.

One of the next steps is to introduce an attribute to choose camera preview size for an available area using some strategy (ratio priority, size priority, etc.)

Another one is to support **detectors** (Barcode, Face, etc.).

Note: I'm going to use that library in Xamarin project, so I'll create bindings for the library and publish it to NuGet.